### PR TITLE
Use get instead direct key index for DISTRO environment

### DIFF
--- a/ulauncher/utils/environment.py
+++ b/ulauncher/utils/environment.py
@@ -17,7 +17,7 @@ with open(pathlib.Path("/etc/os-release")) as stream:
 GDK_BACKEND = os.environ.get("GDK_BACKEND", "").upper()
 XDG_SESSION_TYPE = os.environ.get("XDG_SESSION_TYPE", "").upper()
 DESKTOP_NAME = os.environ.get("XDG_CURRENT_DESKTOP", "") or "Unknown Desktop"
-DISTRO = os_release["PRETTY_NAME"] or "Unknown Distro"
+DISTRO = os_release.get("PRETTY_NAME", "Unknown Distro")
 IS_X11 = XDG_SESSION_TYPE == "X11"
 # This means either X11 or XWayland
 IS_X11_COMPATIBLE = IS_X11 or GDK_BACKEND and GDK_BACKEND.startswith("X11")


### PR DESCRIPTION
When running Ulauncher on ArcoLinux I get a KeyError as such:

```py
╰─ ulauncher                                                                                  
Traceback (most recent call last):
  File "/usr/bin/ulauncher", line 22, in <module>
    from ulauncher.main import main
  File "/usr/lib/python3.10/site-packages/ulauncher/main.py", line 8, in <module>
    import ulauncher.utils.xinit  # noqa: F401
  File "/usr/lib/python3.10/site-packages/ulauncher/utils/xinit.py", line 4, in <module>
    from ulauncher.utils.environment import IS_X11_COMPATIBLE
  File "/usr/lib/python3.10/site-packages/ulauncher/utils/environment.py", line 20, in <module>
    DISTRO = os_release["PRETTY_NAME"] or "Unknown Distro"
KeyError: 'PRETTY_NAME'
```

because my `/etc/os-release` file does not have a `PRETTY_NAME`

```asciidoc
╰─ cat /etc/os-release                                                                           
NAME=ArcoLinux
ID=arch
ID_LIKE=arch
BUILD_ID=rolling
ANSI_COLOR="0;36"
HOME_URL="https://arcolinux.info/"
SUPPORT_URL="https://arcolinuxforum.com/"
BUG_REPORT_URL="https://github.com/arcolinux"
LOGO=arcolinux-hello
```

I modified the environment to fallback to `Unknown Distro` if `PRETTY_NAME` is not present in the user's `os-release`